### PR TITLE
fix error logging message

### DIFF
--- a/cri_lib/cri_controller.py
+++ b/cri_lib/cri_controller.py
@@ -109,7 +109,7 @@ class CRIController:
 
         except ConnectionRefusedError:
             logging.error(
-                f"Connection refused: Unable to connect to {self.ip_address}:{self.port}"
+                f"Connection refused: Unable to connect to {host}:{port}"
             )
             return False
         except Exception as e:


### PR DESCRIPTION
fix logging error message when the connection was refused, since `self.ip_address` seems to be replaced by `host`, and `self.port` was just `port` inside `connect(...)`