### PR TITLE
Refactor logging & prints to use regular Python loggers

### DIFF
--- a/cri_lib/__init__.py
+++ b/cri_lib/__init__.py
@@ -2,7 +2,6 @@
 .. include:: ../README.md
 """
 
-
 from .robot_state import (
     RobotMode,
     KinematicsState,

--- a/cri_lib/cri_errors.py
+++ b/cri_lib/cri_errors.py
@@ -1,12 +1,14 @@
 class CRIError(Exception):
-    pass
+    """Base class for CRI-related errors."""
 
 class CRIConnectionError(CRIError):
+    """Raised when there is a connection error."""
     def __init__(self, message="Not connected to iRC or connection lost."):
         self.message = message
         super().__init__(self.message)
 
 class CRICommandTimeOutError(CRIError):
+    """Raised when a command times out."""
     def __init__(self, message="Time out waiting for command response."):
         self.message = message
         super().__init__(self.message)

--- a/cri_lib/cri_protocol_parser.py
+++ b/cri_lib/cri_protocol_parser.py
@@ -18,6 +18,7 @@ from .robot_state import (
     ReferencingAxisState,
 )
 
+logger = logging.getLogger(__name__)
 
 class CRIProtocolParser:
     """Class handling the parsing of CRI messages to the robot state."""
@@ -99,7 +100,7 @@ class CRIProtocolParser:
                 return self._parse_execerror(parts[3:-1])
 
             case _:
-                logging.debug(
+                logger.debug(
                     "Unknown message type %s received:\n%s", parts[2], " ".join(parts)
                 )
                 return None
@@ -274,7 +275,7 @@ class CRIProtocolParser:
                     segment_start_idx += 8
 
                 case _:
-                    logging.debug(
+                    logger.debug(
                         "Unknown segment in status message: %s",
                         parameters[segment_start_idx],
                     )
@@ -353,7 +354,7 @@ class CRIProtocolParser:
                 variables[parameters[idx + 1]] = PosVariable(*values)
                 idx += 17
             else:
-                logging.debug(
+                logger.debug(
                     "Unknown variable type in VARIABLES message: %s", parameters[idx]
                 )
                 idx += 1
@@ -401,7 +402,7 @@ class CRIProtocolParser:
                     self.robot_state.active_control = False
                 return "Active_false"
             else:
-                logging.debug("Unknown Active state: %s", parameters[1])
+                logger.debug("Unknown Active state: %s", parameters[1])
 
         return None
 
@@ -453,7 +454,7 @@ class CRIProtocolParser:
                     self.robot_state.gripper_type = gripper
 
         else:
-            logging.debug("MESSAGE: %s", " ".join(parameters))
+            logger.debug("MESSAGE: %s", " ".join(parameters))
 
     def _parse_can_bridge(self, parameters: list[str]) -> dict[str, any] | None:
         """Parses a can bridge message.

--- a/examples/relative_move.py
+++ b/examples/relative_move.py
@@ -1,34 +1,44 @@
+import logging
 from cri_lib import CRIController
+
+# 🔹 Configure logging
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
 
 # CRIController is the main interface for controlling the iRC
 controller = CRIController()
 
-#connect to default iRC IP
-#controller.connect("192.168.3.11")
+# Connect to default iRC IP
+# controller.connect("192.168.3.11")
 if not controller.connect("127.0.0.1", 3921):
-    print("Unable to connect")
+    logger.error("Unable to connect to iRC! Ensure the simulator is running.")
     quit()
 
-#acquire active control.
+# Acquire active control.
 controller.set_active_control(True)
 
-print("enable")
-#enable motors
+logger.info("Acquired active control.")
+
+# Enable motors
+logger.info("Enabling motors...")
 controller.enable()
 
-print("waiting")
-#wait until kinematics are ready to move
+# Wait until kinematics are ready
+logger.info("Waiting for kinematics to be ready...")
 controller.wait_for_kinematics_ready(10)
 
 controller.set_override(100.0)
 
-print("move")
-#relative move x,y,z +20mm and back
-controller.move_base_relative(20.0, 20.0, 20.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, wait_move_finished=True, move_finished_timeout= 1000)
-controller.move_base_relative(-20.0, -20.0, -20.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, wait_move_finished=True, move_finished_timeout= 1000)
+# Perform relative movement
+logger.info("Moving base relative: +20mm in X, Y, Z...")
+controller.move_base_relative(20.0, 20.0, 20.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, wait_move_finished=True, move_finished_timeout=1000)
 
+logger.info("Moving back: -20mm in X, Y, Z...")
+controller.move_base_relative(-20.0, -20.0, -20.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, wait_move_finished=True, move_finished_timeout=1000)
 
-
-#Disable motors and disconnect
+# Disable motors and disconnect
+logger.info("Disabling motors and disconnecting...")
 controller.disable()
 controller.close()
+
+logger.info("Script execution completed successfully.")

--- a/examples/start_program.py
+++ b/examples/start_program.py
@@ -1,66 +1,70 @@
+import logging
 from time import sleep
 
 from cri_lib import CRIController
 
+# 🔹 Configure logging
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
 # CRIController is the main interface for controlling the iRC
 controller = CRIController()
 
 #connect to default iRC IP
 #if not controller.connect("127.0.0.1", 3921):
 if not controller.connect("192.168.3.11"):
-    print("Unable to connect")
+    logger.error("Unable to connect")
     quit()
 
 #acquire active control.
 controller.set_active_control(True)
 
-print("enable")
+logger.info("Enabling motors...")
 #enable motors
 controller.enable()
 
-print("waiting")
+logger.info("Waiting for kinematics to be ready...")
 #wait until kinematics are ready to move
 controller.wait_for_kinematics_ready(10)
 
 controller.set_override(50.0)
 
-print("Load program")
-if not controller.load_programm("ReBeL_6DOF_01_Tischtest.xml"):
-    print("unable to load programm")
+logger.info("Load program")
+if not controller.load_programm("ReBeL_MoveToZero.xml"):
+    logger.error("unable to load programm")
     controller.disable()
     controller.close()
     quit()
 
-print("Start program")
+logger.info("Start program")
 if not controller.start_programm():
-    print("Unable to start programm")
+    logger.error("Unable to start programm")
     controller.disable()
     controller.close()
     quit()
 
 sleep(5)
 
-print("Pause program")
+logger.info("Pause program")
 if not controller.pause_programm():
-    print("Unable to pause programm")
+    logger.error("Unable to pause programm")
     controller.disable()
     controller.close()
     quit()
 
 sleep(5)
 
-print("Start programm again")
+logger.info("Start programm again")
 if not controller.start_programm():
-    print("Unable to start programm")
+    logger.error("Unable to start programm")
     controller.disable()
     controller.close()
     quit()
 
 sleep(5)
 
-print("Stop program")
+logger.info("Stop program")
 if not controller.stop_programm():
-    print("Unable to stop programm")
+    logger.error("Unable to stop programm")
     controller.disable()
     controller.close()
     quit()


### PR DESCRIPTION
Hi @cpr-bar,

we are starting to use this library to interface with our SCARA, and would like to start contributing bugfixes.

With this PR we would like to propose using the Python logging framework through named loggers, because it makes it easier to filter log events.

We also replaced `print`s in the examples by log messages such that we get timestamps.

Credits to the code changes go to @rapith777 who just began his thesis project with us.