### PR TITLE
Add `KinematicsState` for value 98

### DIFF
--- a/cri_lib/robot_state.py
+++ b/cri_lib/robot_state.py
@@ -27,6 +27,7 @@ class KinematicsState(Enum):
     VIRTUAL_BOX3 = 33
     VIRTUAL_BOX4 = 34
     VIRTUAL_BOX5 = 35
+    UNKNOWN = 98
     MOTION_NOT_ALLOWED = 99
 
 


### PR DESCRIPTION
When talking to our SCARA, we received `KinematicsState` values of `98` which are not implemented or documented as far as we could tell.

This adds them as `KinematicsState.UNKNOWN`, however I'm sure there should be a better explanation?