### PR TITLE
Add missing "frame" parameters

### DIFF
--- a/cri_lib/cri_controller.py
+++ b/cri_lib/cri_controller.py
@@ -817,6 +817,7 @@ class CRIController:
         E2: float,
         E3: float,
         velocity: float,
+        frame: str = "#base",
         wait_move_finished: bool = False,
         move_finished_timeout: float | None = 300.0,
         acceleration: float | None = None,
@@ -845,7 +846,7 @@ class CRIController:
             requires igus Robot Control version >= V14-004-1 on robot controller
         """
         command = (
-            f"CMD Move RelativeBase {X} {Y} {Z} {A} {B} {C} {E1} {E2} {E3} {velocity}"
+            f"CMD Move RelativeBase {X} {Y} {Z} {A} {B} {C} {E1} {E2} {E3} {velocity} {frame}"
         )
 
         if (
@@ -893,6 +894,7 @@ class CRIController:
         E2: float,
         E3: float,
         velocity: float,
+        frame: str = "#base",
         wait_move_finished: bool = False,
         move_finished_timeout: float | None = 300.0,
         acceleration: float | None = None,
@@ -921,7 +923,7 @@ class CRIController:
             requires igus Robot Control version >= V14-004-1 on robot controller
         """
         command = (
-            f"CMD Move RelativeTool {X} {Y} {Z} {A} {B} {C} {E1} {E2} {E3} {velocity}"
+            f"CMD Move RelativeTool {X} {Y} {Z} {A} {B} {C} {E1} {E2} {E3} {velocity} {frame}"
         )
 
         if (


### PR DESCRIPTION
# Problem
It seems the `frame` parameter is currently missing in the `move_base_relative` and `move_tool_relative` methods of the `CRIController`. (But it is part of the documentation of both methods)

# Example
```python
from cri_lib import CRIController

def run():
    controller = CRIController()
    controller.connect("127.0.0.1", 3921)
    controller.set_active_control(True)
    controller.enable()
    controller.wait_for_kinematics_ready(10)
    controller.set_override(50)
    controller.move_base_relative(
        X = -200,
        Y = -200,
        Z = 0,
        A = 0,
        B = 0,
        C = 0,
        E1 = 0,
        E2 = 0,
        E3 = 0,
        velocity = 100,
        wait_move_finished = True,
        move_finished_timeout = 10,
        acceleration = 20
    )

if __name__ == '__main__':
    run()
```
I get the following error messages in the simulator application:
![grafik](https://github.com/user-attachments/assets/5ac25f6d-06ff-4b78-b2c3-09a1dcb775d2)

# Fix
I added the `frame` parameter to both methods and also added it to the `command` string.
