### PR TITLE
Update cri_controller.py

### DIFF
--- a/cri_lib/cri_controller.py
+++ b/cri_lib/cri_controller.py
@@ -1124,7 +1124,7 @@ class CRIController:
         if (id < 0) or (id > 63):
             raise ValueError
 
-        command = f"CMD DOUT {id} {str(value).lower()}"
+        command = f"CMD DOUT {id+1} {str(value).lower()}"
 
         if (msg_id := self._send_command(command, True)) is not None:
             if (


### PR DESCRIPTION
When creating an .xml program with the igus Robot Control software, digital outputs are numbered from 1 to 64. In the CRI Python library, however, digital outputs are numbered from 0 to 63. Shifting the “id” parameter by +1 ( –1) can help prevent misunderstandings.