### PR TITLE
Account for `LOGMSG`, `EXECPAUSE` and `EXECACK` messages in parser

### DIFF
--- a/cri_lib/cri_protocol_parser.py
+++ b/cri_lib/cri_protocol_parser.py
@@ -95,8 +95,14 @@ class CRIProtocolParser:
                 if (answer := self._parse_info(parts[3:-1])) is not None:
                     result = {"answer": answer}
 
-            case "EXECEND":
-                result = {"answer": "EXECEND"}
+            case "LOGMSG":
+                # every received message is logged, so there's no need to log it again
+                pass
+
+            case "EXECACK" | "EXECPAUSE" | "EXECEND":
+                # the messages doesn't contain a command message ID,
+                # therefore only the category can be subscribed to.
+                result = {"answer": str(cmd_category)}
 
             case "EXECERROR":
                 result = self._parse_execerror(parts[3:-1])


### PR DESCRIPTION
* `LOGMSG` are ignored, because every received message is logged already
* `EXECACK` and `EXECPAUSE` are handled like `EXECEND`: One may subscribe the category, but detailed information and association with the command message is not available.

Closes #34

--------------

I noticed that `EXECERROR → _parse_execerror` results in a `{"answer": "EXECEND", ...` dict, leading to a potential conflict with `EXECEND` messages.
This is likely because the rest of the codebase only subscribes to `EXECEND`, never to `EXECERROR`.

I think one clean solution would be to include the command `msg_id` and aggregate not only one, but many responses per `msg_id`.

This would also account for the multiple `EXECACK` messages incoming during a multi-step program execution (if I understood that correctly).

Furthermore it would provide means to aggregate further details like `cmdNr, progNr, programName` in a sequence of typed response message objects.

In another project I use a similar pattern with MQTT communication, where every command has a "conversation_id" that's included in all response messages of different types.